### PR TITLE
Fixes #10 : 08, 09, etc being parsed as octal

### DIFF
--- a/lib/musicmetadata.js
+++ b/lib/musicmetadata.js
@@ -164,8 +164,8 @@ function cleanupArtist(origVal) {
 //or 1 to no : 1, of : 0
 function cleanupTrack(origVal) {
   var split = origVal.toString().split('/');
-  var number = parseInt(split[0]) || 0;
-  var total = parseInt(split[1]) || 0;
+  var number = parseInt(split[0], 10) || 0;
+  var total = parseInt(split[1], 10) || 0;
   return { no : number, of : total };
 }
 


### PR DESCRIPTION
`parseInt` is getting the numbers with a leading 0, so it is attempting to parse them as octal.  this is causing numbers like 08, 09, 18, 19, etc to be displayed as 0.
