### PR TITLE
adds duration to metadata object

### DIFF
--- a/lib/musicmetadata.js
+++ b/lib/musicmetadata.js
@@ -42,7 +42,7 @@ MusicMetadata.prototype.parse = function() {
 var emitClosure = function(self) {
   var metadata = { title : '', artist : [], albumartist : [], album : '',
                    year : 0, track : { no : 0, of : 0 }, genre : [],
-                   disk : { no : 0, of : 0 }, picture : {} };
+                   disk : { no : 0, of : 0 }, picture : {}, duration: 0 };
   
   var aliased = {};
   
@@ -95,16 +95,17 @@ var emitClosure = function(self) {
     
     //we need to do something special for these events
     //TODO: parseInt will return NaN for strings
-    if (event === 'TRACKTOTAL' || event === 'DISCTOTAL') {
-      var evt;
-      if (event === 'TRACKTOTAL') evt = 'track';
-      if (event === 'DISCTOTAL') evt = 'disk';
-      
-      var cleaned = parseInt(value)
-      if (!aliased.hasOwnProperty(evt)) {
-        aliased[evt] = { no : 0, of : cleaned };
+    if (event === 'TRACKTOTAL' || event === 'DISCTOTAL',event === 'LENGTH' || 
+        event === 'TLEN' || event === 'length' || event === 'Length') {
+      var cleaned = typeof value === 'number' ? 
+                    parseInt(value) : parseInt(Number(value));
+
+      if (event === 'TRACKTOTAL') {
+        aliased['track']['of'] = cleaned;
+      } else if (event === 'DISCTOTAL') {
+        aliased['disc'] = { no : 0, of : cleaned };
       } else {
-        aliased[evt]['of'] = cleaned;
+        aliased['duration'] = cleaned
       }
     }
     
@@ -186,6 +187,7 @@ function cleanupPicture(picture) {
 //mappings for common metadata types(id3v2.3, id3v2.2, id4, vorbis, APEv2)
 var MAPPINGS = [
   [ 'title',       'TIT2', 'TT2', '©nam', 'TITLE' ],
+  [ 'length',      'LENGTH',      'TLEN', 'Length'],
   [ 'artist',      'TPE1', 'TP1', '©ART', 'ARTIST' ],
   [ 'albumartist', 'TPE2', 'TP2', 'aART', 'ALBUMARTIST', 'ENSEMBLE' ], 
   [ 'album',       'TALB', 'TAL', '©alb', 'ALBUM' ], 


### PR DESCRIPTION
Hi,

This is a great library, thanks for working on it.  I needed the ability to add duration to the mp3 metadata and figured I'd submit a pull request so I wasn't just monkey patching my own code.  I'm not terribly familiar with ID3 tags and dealing with parsing mp3s so any feedback is welcome.
