### PR TITLE
Duration of non file streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ You can also read the duration; reading the duration may be slow so only set thi
 var parser = mm(fs.createReadStream('sample.mp3'), { duration: true });
 ```
 
+Note that in order to read the duration for streams that are not file streams, you must also pass the size of the file in bytes.
+```javascript
+var parser = mm(fs.createReadStream('sample.mp3'), { duration: true, fileSize: 26838 });
+```
 
 This will output the standard music metadata:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,9 +35,15 @@ var MusicMetadata = module.exports = function (stream, opts) {
         fs.stat(stream.path, function (err, stats) {
           if (err) throw err;
           cb(stats.size);
-        })
+        });
+      } else if (opts.fileSize) {
+        process.nextTick(function() {
+          cb(opts.fileSize);
+        });
       } else if (opts.duration) {
-        self.emit('done', Error('reading duration is not supported on non file streams'))
+        self.emit(
+          'done',
+          Error('for non file streams, specify the size of the stream with a fileSize option'));
       }
     }
     this.stream = stream;

--- a/test/test-non-file-stream-duration.js
+++ b/test/test-non-file-stream-duration.js
@@ -1,0 +1,25 @@
+var path    = require('path');
+var fs      = require('fs');
+var through = require('through');
+var mm      = require('../lib/index');
+var test    = require('tape');
+
+test('nonfilestream', function (t) {
+  t.plan(1);
+
+  // shim process for browser-based tests
+  if (!process.nextTick)
+    process.nextTick = function(cb) { setTimeout(cb, 0); };
+
+  var sample = path.join(__dirname, 'samples/id3v2-duration-allframes.mp3');
+  var nonFileStream = through(
+    function write(data) { this.queue(data); },
+    function end() { this.queue(null); });
+  fs.createReadStream(sample).pipe(nonFileStream);
+
+  new mm(nonFileStream, { duration: true, fileSize: 47889 })
+    .on('metadata', function (result) {
+      t.equal(result.duration, 1);
+      t.end();
+    });
+});


### PR DESCRIPTION
This update adds the ability to measure the duration of audio streams that are not file streams. This can be done by passing the explicit file size through the options.
