### PR TITLE
Fixes for false positive audio frames

### DIFF
--- a/test/test-id3v2-duration-allframes.js
+++ b/test/test-id3v2-duration-allframes.js
@@ -7,7 +7,8 @@ test('id3v2-duration-allframes', function (t) {
   t.plan(3);
 
   var sample = path.join(__dirname, 'samples/id3v2-duration-allframes.mp3');
-  new id3(fs.createReadStream(sample), {'duration': true})
+  var stream = fs.createReadStream(sample, { autoClose: false });
+  new id3(stream, {'duration': true})
     .on('metadata', function (result) {
       t.deepEqual(result,
         { title: 'Turkish Rondo',
@@ -26,6 +27,7 @@ test('id3v2-duration-allframes', function (t) {
     })
     .on('done', function (err) {
       if (err) throw err;
+      stream.destroy();
       t.ok(true, 'done called');
     });
 })

--- a/test/test-non-file-stream-duration.js
+++ b/test/test-non-file-stream-duration.js
@@ -15,10 +15,12 @@ test('nonfilestream', function (t) {
   var nonFileStream = through(
     function write(data) { this.queue(data); },
     function end() { this.queue(null); });
-  fs.createReadStream(sample).pipe(nonFileStream);
+  var fileStream = fs.createReadStream(sample, { autoClose: false });
+  fileStream.pipe(nonFileStream);
 
   new mm(nonFileStream, { duration: true, fileSize: 47889 })
     .on('metadata', function (result) {
+      fileStream.destroy();
       t.equal(result.duration, 1);
       t.end();
     });


### PR DESCRIPTION
In testing out some sample MP3s, I encountered one that would not only parse incorrectly, but it would actually break the parser so it would go into an infinite parse loop; this was because a `NaN` was being passed into `new strtok.BufferType(...)` due to invalid header values. This would cause it to continually read 0 byte buffers, thus never terminating.

This is just another case of a false positive for the frame synchronizer, which is very common. Although you cannot tell for sure when a _real_ audio frame is encountered, there are a few clues. Additionally, it's not guaranteed that the pre-synchronization frames will fall along a four-byte boundary. To improve the synchronization algorithm, I updated the following:
- Frame seeking is changed to be a byte-by-byte scan.
- Continue seeking the first frame if:
  - The MPEG version is `01` (reserved).
  - The MPEG layer is `00` (reserved).
  - The bitrate index is `1111` (bad).
  - The sampling rate frequency index is `11` (reserved).

Even after all this, my sample file failed. The matched frame appeared to be an MPEG1 layer 1 frame. Since this library will mostly be used for MP3s, I also added code to continue seeking the first frame if the frame isn't identified as an MPEG1 layer 3 frame. Although this is behavior is defaulted to true, you can override it by setting an `allowNonMP3Frames` option to `true`. Because I introduced a new option that can be consumed by parsers, I changed the parsers so they receive an options object instead of just a boolean flag.

After all these changes, my MP3 can be successfully parsed. I've added a test case and the mp3 to the samples directory to prove it out.
