### PR TITLE
File stream closing

### DIFF
--- a/test/test-id3v2-duration-allframes.js
+++ b/test/test-id3v2-duration-allframes.js
@@ -7,7 +7,8 @@ test('id3v2-duration-allframes', function (t) {
   t.plan(3);
 
   var sample = path.join(__dirname, 'samples/id3v2-duration-allframes.mp3');
-  new id3(fs.createReadStream(sample), {'duration': true})
+  var stream = fs.createReadStream(sample, { autoClose: false });
+  new id3(stream, {'duration': true})
     .on('metadata', function (result) {
       t.deepEqual(result,
         { title: 'Turkish Rondo',
@@ -26,6 +27,7 @@ test('id3v2-duration-allframes', function (t) {
     })
     .on('done', function (err) {
       if (err) throw err;
+      stream.destroy();
       t.ok(true, 'done called');
     });
 })

--- a/test/test-non-file-stream-duration.js
+++ b/test/test-non-file-stream-duration.js
@@ -15,10 +15,12 @@ test('nonfilestream', function (t) {
   var nonFileStream = through(
     function write(data) { this.queue(data); },
     function end() { this.queue(null); });
-  fs.createReadStream(sample).pipe(nonFileStream);
+  var fileStream = fs.createReadStream(sample, { autoClose: false });
+  fileStream.pipe(nonFileStream);
 
   new mm(nonFileStream, { duration: true, fileSize: 47889 })
     .on('metadata', function (result) {
+      fileStream.destroy();
       t.equal(result.duration, 1);
       t.end();
     });


### PR DESCRIPTION
One of the tests intermittently fails. It seems to be because two tests are opening the same file, and this is causing the second test to sometimes receive an unexpected `close` event from the stream. This change manually closes the underlying streams in a predictable manner.
