### PR TITLE
Add Xing headers to be read as info headers

### DIFF
--- a/lib/id3v2.js
+++ b/lib/id3v2.js
@@ -154,7 +154,7 @@ module.exports = function (stream, callback, done, readDuration, fileSize) {
         var frameDataLeft = audioFrameHeader.frame_size - 4 - cb.offset;
 
         var id = v.toString('ascii', 0, 4);
-        if (id !== 'Xtra' && id !== 'Info') {
+        if (id !== 'Xtra' && id !== 'Info' && id !== 'Xing') {
           return new strtok.BufferType(frameDataLeft);
         }
 


### PR DESCRIPTION
As I pointed out in https://github.com/leetreveil/musicmetadata/issues/42, Xing headers are currently not being read (as information headers). These headers (to be exact, an extended version of them) are generated by LAME by default for VBR files these days, so they are very widespread.

I was however mistaken in believing there is no logic in this repository for reading Xing and similar information headers. The only thing I had to change was adding the string 'Xing' as a valid header ID for info headers.

The results for a quick test script with two sample mp3s (the VBR version being generated by `lame -V2 cbr.mp3 vbr.mp3`) are as follows:

before my 17-character change:

```
-=[cbr]=-
duration: 221
cbr: 55ms

-=[vbr]=-
duration: 221
vbr: 1713ms
```

after my change:

```
-=[cbr]=-
duration: 221
cbr: 16ms

-=[vbr]=-
duration: 221
vbr: 12ms
```

Overall, this seems to greatly improve duration calculation performance for many, probably the majority of, VBR mp3s out there.

Further note: I could not find any information about an information header with the id 'Xtra'. I left this in as it doesn't hurt, but I'm not sure it's necessary.
