### PR TITLE
Emit metadata even even if no metadata found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,10 +106,11 @@ MusicMetadata.prototype.readEvent = function (event, value) {
       }
     }
 
-    // don't emit the metadata event if nothing
-    // ever gets added to the metadata object
+    // emit metadata event even if nothing is added.
     if (Object.keys(this.aliased).length > 0) {
       this.emit('metadata', this.metadata);
+    } else {
+      this.emit('metadata', null);
     }
 
     this.emit('done', value);


### PR DESCRIPTION
A lack of metadata can be useful to know. And it only takes one if statement at the beginning of the callback to get old behaviour.
