### PR TITLE
id3v2 parseMetadata - change search to indexOf

### DIFF
--- a/lib/id3v2.js
+++ b/lib/id3v2.js
@@ -215,7 +215,7 @@ function parseMetadata (data, header, done) {
 
     // Last frame. Check first char is a letter, bit of defensive programming  
     if (frameHeader.id === '' || frameHeader.id === '\u0000\u0000\u0000\u0000' ||
-        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.search(frameHeader.id[0]) === -1) {
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.indexOf(frameHeader.id[0]) === -1) {
       break;
     }
 


### PR DESCRIPTION
Regex (search) not needed, indexOf will work for a char comparison.
Also will prevent invalid search regex's

Given frameHeader.id = '):=T'

/home/ec2-user/src/node_modules/musicmetadata/lib/id3v2.js:219
        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.search(frameHeader.id[0]) === -1) {
                                     ^
SyntaxError: Invalid regular expression: /)/: Unmatched ')'
    at new RegExp (<anonymous>)
    at RegExp (<anonymous>)
    at String.search (native)
    at parseMetadata (/home/ec2-user/src/node_modules/musicmetadata/lib/id3v2.js:219:38)
    at /home/ec2-user/src/node_modules/musicmetadata/lib/id3v2.js:38:9
    at emitData (/home/ec2-user/src/node_modules/musicmetadata/node_modules/strtok2/lib/strtok.js:351:20)
    at Stream.dataListener (/home/ec2-user/src/node_modules/musicmetadata/node_modules/strtok2/lib/strtok.js:414:11)
    at Stream.emit (events.js:95:17)
    at Stream.<anonymous> (/home/ec2-user/src/node_modules/musicmetadata/lib/index.js:65:13)
    at Stream.g (events.js:180:16)