### PR TITLE
Ensure done is called when no tag data could be extracted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,9 +47,8 @@ var MusicMetadata = module.exports = function (stream, opts) {
 
   var aliased = {};
 
-  var hasReadData = false;
+  var hasCalledDone = false;
   istream.once('data', function (result) {
-    hasReadData = true;
     var parser = common.getParserForMediaType(headerTypes, result);
     parser(istream, function (event, value) {
       if (value === null) return;
@@ -66,7 +65,7 @@ var MusicMetadata = module.exports = function (stream, opts) {
   });
 
   istream.on('end', function () {
-    if (!hasReadData) {
+    if (!hasCalledDone) {
       done(new Error('Could not read any data from this stream'))
     }
   })
@@ -77,7 +76,8 @@ var MusicMetadata = module.exports = function (stream, opts) {
     done(new Error('Unexpected end of stream'));
   }
 
-  function done (exception) {
+  function done(exception) {
+    hasCalledDone = true;
     istream.removeListener('close', onClose);
 
     // We only emit aliased events once the 'done' event has been raised,


### PR DESCRIPTION
I've found with some media files that neither `metadata` nor `done` are emitted. When such a file is encountered, calling code silently ceases progressing without getting an error. Not sure if this is a bug or I'm using this library incorrectly.

Looked in `index.js` and found the `hasReadData` flag, used to ensure that when the input stream ends and nothing else has happened, `done` will be called instead. The problem is that the parser may not emit any usable tags, but `hasReadData` has been set to `true`, so nothing is emitted.

To protect against this I've replaced `hasReadData` with `hasCalledDone`, which (as its name suggests) literally records whether `done` has been called.