### PR TITLE
Check hasOwnProperty for frameData loop

### DIFF
--- a/lib/id3v2.js
+++ b/lib/id3v2.js
@@ -223,7 +223,9 @@ function parseMetadata (data, header, done) {
     var frameDataBytes = data.slice(offset, offset += frameHeader.length);
     var frameData = readFrameData(frameDataBytes, frameHeader, header.major);
     for (var pos in frameData) {
-      frames.push([frameHeader.id, frameData[pos]])
+      if (frameData.hasOwnProperty(pos)) {
+        frames.push([frameHeader.id, frameData[pos]])
+      }
     }
   }
   return frames;


### PR DESCRIPTION
Without this, tagging breaks for songs with artist data in an environment where the Array prototype has been extended.

I needed this fix to use musicmetadata on the client with [Ember](http://emberjs.com/).