### PR TITLE
fix error when callback is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,9 @@ var MusicMetadata = module.exports = function (stream, opts, callback) {
       }
     }
 
-    callback(exception, metadata)
+    if (callback) {
+      callback(exception, metadata)
+    }
     return strtok.DONE;
   }
 


### PR DESCRIPTION
I ran into this error when running musicmetadata as part of my project on windows:

```
C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\lib\index.js:108
    callback(exception, metadata)
    ^
TypeError: undefined is not a function
    at done (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\lib\index.js:108:5)
    at C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\lib\id3v1.js:14:14
    at Stream.done (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\lib\common.js:32:5)
    at Stream.emit (events.js:129:20)
    at drain (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\node_modules\through\index.js:34:23)
    at Stream.stream.queue.stream.push (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\node_modules
\through\index.js:45:5)
    at Stream.end (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\node_modules\through\index.js:15:
35)
    at _end (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\node_modules\through\index.js:65:9)
    at Stream.stream.end (C:\Users\benkaiser\GIT\node-music-player\node_modules\musicmetadata\node_modules\through\index
.js:74:5)
    at ReadStream.onend (_stream_readable.js:505:10)
```

This pull request should fix that.