### PR TITLE
delete Math.round and floor for raw duration

### DIFF
--- a/lib/asf.js
+++ b/lib/asf.js
@@ -185,7 +185,7 @@ function FilePropertiesObject (nextState, size) {
 FilePropertiesObject.prototype.parse = function (callback, data, done) {
   // in miliseconds
   var playDuration = parseQWordAttr(data.slice(40, 48)) / 10000
-  callback('duration', Math.round(playDuration / 1000))
+  callback('duration', playDuration / 1000)
 
   if (this.nextState === finishedState) done()
   return this.nextState

--- a/lib/flac.js
+++ b/lib/flac.js
@@ -66,7 +66,7 @@ BlockDataState.prototype.parse = function (callback, data) {
     var sampleRate = common.strtokUINT24_BE.get(data, 10) >> 4
     var totalSamples = data.readUInt32BE(14)
     var duration = totalSamples / sampleRate
-    callback('duration', Math.round(duration))
+    callback('duration', duration)
   }
 
   return this.nextStateFactory()

--- a/lib/id3v2.js
+++ b/lib/id3v2.js
@@ -127,7 +127,7 @@ module.exports = function (stream, callback, done, readDuration, fileSize) {
             // subtract non audio stream data from duration calculation
             size = size - cb.id3Header.size
             var kbps = (header.bitrate * 1000) / 8
-            callback('duration', Math.round(size / kbps))
+            callback('duration', size / kbps)
             cb(done())
           })
           return strtok.DEFER

--- a/lib/id4.js
+++ b/lib/id4.js
@@ -70,7 +70,7 @@ module.exports = function (stream, callback, done, readDuration) {
         // TODO: support version 1
         var sampleRate = v.readUInt32BE(12)
         var duration = v.readUInt32BE(16)
-        callback('duration', Math.floor(duration / sampleRate))
+        callback('duration', duration / sampleRate)
         cb.state = 0
         return strtok.UINT32_BE
     }

--- a/lib/ogg.js
+++ b/lib/ogg.js
@@ -14,7 +14,7 @@ module.exports = function (stream, callback, done, readDuration) {
 
   stream.on('end', function () {
     if (readDuration) {
-      callback('duration', Math.floor(header.pcm_sample_pos / sampleRate))
+      callback('duration', header.pcm_sample_pos / sampleRate)
       done()
     }
   })

--- a/test/test-asf.js
+++ b/test/test-asf.js
@@ -22,7 +22,7 @@ test('asf', function (t) {
     t.strictEqual(result.disk.no, 0, 'disk no')
     t.strictEqual(result.disk.of, 0, 'disk of')
     t.strictEqual(result.genre[0], 'Rock', 'genre 0')
-    t.strictEqual(result.duration, 245, 'duration')
+    t.strictEqual(result.duration, 244.885, 'duration')
     t.end()
   }) // aliased tests
     .on('title', function (result) {
@@ -48,7 +48,7 @@ test('asf', function (t) {
       t.strictEqual(result[0], 'Rock', 'aliased genre')
     })
     .on('duration', function (result) {
-      t.strictEqual(result, 245, 'aliased duration')
+      t.strictEqual(result, 244.885, 'aliased duration')
     })
     // raw tests
     .on('WM/AlbumTitle', function (result) {

--- a/test/test-audio-frame-header-bug.js
+++ b/test/test-audio-frame-header-bug.js
@@ -12,7 +12,7 @@ test('audio-frame-header-bug', function (t) {
 
   mm(sample, { duration: true }, function (err, result) {
     t.error(err)
-    t.strictEqual(result.duration, 201)
+    t.strictEqual(result.duration, 200.59591666666665)
     t.end()
   })
 })

--- a/test/test-flac.js
+++ b/test/test-flac.js
@@ -24,7 +24,7 @@ test('flac', function (t) {
     t.strictEqual(result.genre[0], 'Alt. Rock', 'genre')
     t.strictEqual(result.picture[0].format, 'jpg', 'picture format')
     t.strictEqual(result.picture[0].data.length, 175668, 'picture length')
-    t.strictEqual(result.duration, 272, 'duration')
+    t.strictEqual(result.duration, 271.7733333333333, 'duration')
     t.end()
   })
     // aliased tests
@@ -52,7 +52,7 @@ test('flac', function (t) {
       t.strictEqual(result[0], 'EAC-Secure Mode', 'aliased comment')
     })
     .on('duration', function (result) {
-      t.strictEqual(result, 272, 'aliased duration')
+      t.strictEqual(result, 271.7733333333333, 'aliased duration')
     })
     // raw tests
     .on('TITLE', function (result) {

--- a/test/test-id3v2-duration-allframes.js
+++ b/test/test-id3v2-duration-allframes.js
@@ -22,10 +22,10 @@ test('id3v2-duration-allframes', function (t) {
         genre: [ 'Classical' ],
         disk: { no: 0, of: 0 },
         picture: {},
-      duration: 1 })
+      duration: 1.48928125 })
     t.end()
   })
     .on('duration', function (result) {
-      t.strictEqual(result, 1, 'duration')
+      t.strictEqual(result, 1.48928125, 'duration')
     })
 })

--- a/test/test-id4.js
+++ b/test/test-id4.js
@@ -26,11 +26,11 @@ test('id4', function (t) {
     t.strictEqual(result.picture[0].data.length, 196450, 'picture 0 length')
     t.strictEqual(result.picture[1].format, 'jpg', 'picture 1 format')
     t.strictEqual(result.picture[1].data.length, 196450, 'picture 1 length')
-    t.strictEqual(result.duration, 2, 'metadata duration')
+    t.strictEqual(result.duration, 2.2058956916099772, 'metadata duration')
     t.end()
   })
     .on('duration', function (result) {
-      t.strictEqual(result, 2, 'duration')
+      t.strictEqual(result, 2.2058956916099772, 'duration')
     })
     // aliased tests
     .on('title', function (result) {

--- a/test/test-regress-GH-56.js
+++ b/test/test-regress-GH-56.js
@@ -12,7 +12,7 @@ test('mp3 cbr calculation', function (t) {
 
   id3(sample, {'duration': true}, function (err, result) {
     t.error(err)
-    t.strictEqual(result.duration, 373, 'duration')
+    t.strictEqual(result.duration, 373.329375, 'duration')
     t.end()
   })
 })


### PR DESCRIPTION
I want to get raw duration. so I deleted Math.round and Math.floor .
but if users want integer duration, they must use Math.round, Math.floor or Math.ceil by oneself.
