### PR TITLE
Use user-provided fileSize option as law, not mere suggestion.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,17 +14,17 @@ module.exports = function (stream, opts, callback) {
   var emitter = new events.EventEmitter()
 
   var fsize = function (cb) {
-    if (stream.hasOwnProperty('path')) {
+    if (opts.fileSize) {
+      process.nextTick(function () {
+        cb(opts.fileSize)
+      })
+    } else if (stream.hasOwnProperty('path')) {
       fs.stat(stream.path, function (err, stats) {
         if (err) throw err
         cb(stats.size)
       })
     } else if (stream.hasOwnProperty('fileSize')) {
       stream.fileSize(cb)
-    } else if (opts.fileSize) {
-      process.nextTick(function () {
-        cb(opts.fileSize)
-      })
     } else if (opts.duration) {
       emitter.emit(
         'done',
@@ -32,7 +32,7 @@ module.exports = function (stream, opts, callback) {
     }
   }
 
-  // pipe to an internal stream so we aren't fucking
+  // pipe to an internal stream so we aren't messing
   // with the stream passed to us by our users
   var istream = stream.pipe(through(null, null, {autoDestroy: false}))
 


### PR DESCRIPTION
Re-ordered fsize() so that a user-specified fileSize option will override autmatic fileSize determination.

When the user specifies a fileSize it's not a suggestion: it's the law. Consequently there's no need to go checking for the filesize, just run with it.  If it's wrong, that's the user's problem.