### PR TITLE
Requestjs compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ var parser = mm(fs.createReadStream('sample.mp3'), { duration: true, fileSize: 2
 });
 ```
 
+Now compatible with [request.js](https://github.com/request/request)
+```javascript
+var request = require('request');
+
+// Go get the duration of the MP3.
+mm(request.get('http://www.example.com/some.mp3', { method: "HEAD" }), { duration: true }, function(err, metadata) {
+  
+});
+```
+
 Licence
 -----------------
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,11 @@ module.exports = function (stream, opts, callback) {
   var emitter = new events.EventEmitter()
 
   var fsize = function (cb) {
-    if (stream.hasOwnProperty('path')) {
+    if (stream.hasOwnProperty('responseContent') && stream.responseContent.hasOwnProperty('headers')) { // is a web stream from request.js, https://github.com/request/request, or something very similar.
+      process.nextTick(function () {
+        cb(stream.responseContent.headers['content-length']) // Could be hazardous to your health to get the info this way...  It comes from digging in undocumented territory and therefore is subject to change without notice!
+      })
+    } else if (stream.hasOwnProperty('path')) {
       fs.stat(stream.path, function (err, stats) {
         if (err) throw err
         cb(stats.size)

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ module.exports = function (stream, opts, callback) {
   var emitter = new events.EventEmitter()
 
   var fsize = function (cb) {
-    if (stream.hasOwnProperty('responseContent') && stream.responseContent.hasOwnProperty('headers')) { // is a web stream from request.js, https://github.com/request/request, or something very similar.
+    if (stream.hasOwnProperty('responseContent') && stream.responseContent.hasOwnProperty('headers') && stream.responseContent.headers.hasOwnProperty('content-length')) {
+      // is a web stream from request.js, https://github.com/request/request, or something very similar.
       process.nextTick(function () {
         cb(stream.responseContent.headers['content-length']) // Could be hazardous to your health to get the info this way...  It comes from digging in undocumented territory and therefore is subject to change without notice!
       })


### PR DESCRIPTION
Now easy internet streams can determine the duration!

Thus far, after only gentle searching, I've not found any documented way to detect that the stream has what is needed.  So I cheated and used testing for the information I'm looking for.

I also didn't find documentation on the location of said information.  I simply threw the contents out to console.log and looked for it.

While using undocumented data is a bit risky, I found it to be very useful in my application. YMMV.