### PR TITLE
Added the ability to put custom data into the metadata returned to the callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ var parser = mm(fs.createReadStream('sample.mp3'), { duration: true, fileSize: 2
 });
 ```
 
+If you need to pass custom data on to the callback, just use the `customData` option:
+```javascript
+var parser = mm(fs.createReadStream('sample.mp3'), { customData: { recordID:3, someContrivedField:'contrived data', fileName: 'sample.mp3' } }, function (err, metadata) {
+  console.log(metadata.customData.someContrivedField);
+});
+```
+The `customData` option supports all data types, so pass it whatever you need to get what you are doing done.
+
 Licence
 -----------------
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,10 @@ module.exports = function (stream, opts, callback) {
     duration: 0
   }
 
+  if (opts.hasOwnProperty('customData')) {
+    metadata['customData'] = opts.customData;
+  }
+
   var aliased = {}
 
   var hasReadData = false


### PR DESCRIPTION
This makes writing a bulk processor much easier: if you need to know the file path or URL of the source media, simply put it in the customData option and it will be waiting for you when the callback fires.  If you need to know the record ID of the relevant entry in your database, put it in the customData option.

In my case I was parsing a large CSV with data pulled from an RDBMS, needed to get the duration of each MP3, then to create an SQL file to hand back to the DB maintainer.  The code needed both the record ID from the CSV and the duration.  I found no way to have both at the same time: the mm callback had no access to the CSV data.

Adding this change make it so I simply put the CSV's record into the customData option and I could then do what I needed to do to create the SQL statements directly in the callback.  Simple, easy, fast.