### PR TITLE
m4a audio files issue

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -16,7 +16,7 @@ function wrapFileWithStream (file) {
 
   stream.fileSize = function (cb) {
     process.nextTick(function () {
-      cb(file.size)
+      cb(null, file.size)
     })
   }
 

--- a/lib/id3v2.js
+++ b/lib/id3v2.js
@@ -116,7 +116,10 @@ module.exports = function (stream, callback, done, readDuration, fileSize) {
 
         // the stream is CBR if the first 3 frame bitrates are the same
         if (readDuration && fileSize && frameCount === 3 && areAllSame(bitrates)) {
-          fileSize(function (size) {
+          fileSize(function (error, size) {
+            if (error) {
+              return done(error)
+            }
             // subtract non audio stream data from duration calculation
             size = size - cb.id3Header.size
             var kbps = (header.bitrate * 1000) / 8

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,19 +16,19 @@ module.exports = function (stream, opts, callback) {
   var fsize = function (cb) {
     if (opts.fileSize) {
       process.nextTick(function () {
-        cb(opts.fileSize)
+        cb(null, opts.fileSize)
       })
     } else if (stream.hasOwnProperty('path')) {
       fs.stat(stream.path, function (err, stats) {
-        if (err) throw err
-        cb(stats.size)
+        if (err) return cb(err);
+        cb(null, stats.size)
       })
     } else if (stream.hasOwnProperty('fileSize')) {
-      stream.fileSize(cb)
+      stream.fileSize(function(size) {
+        cb(null, size);
+      })
     } else if (opts.duration) {
-      emitter.emit(
-        'done',
-        new Error('for non file streams, specify the size of the stream with a fileSize option'))
+      cb(new Error('for non file streams, specify the size of the stream with a fileSize option'))
     }
   }
 
@@ -72,7 +72,10 @@ module.exports = function (stream, opts, callback) {
   istream.on('end', function () {
     if (!hasReadData) {
       done(new Error('Could not read any data from this stream'))
+      return;
     }
+    
+    done(); // << For some m4a, the data event never calls done()
   })
 
   istream.on('close', onClose)
@@ -80,8 +83,14 @@ module.exports = function (stream, opts, callback) {
   function onClose () {
     done(new Error('Unexpected end of stream'))
   }
+  
+  var doned=false;
 
   function done (exception) {
+    if (doned) {
+      return;
+    }
+    doned=true;
     istream.removeListener('close', onClose)
 
     // We only emit aliased events once the 'done' event has been raised,


### PR DESCRIPTION
- Try to fix issue with some m4a files whose never call the return callback
- fileSize callback function takes an error for the first parameter because we can not use throw exception in this context.
