### PR TITLE
Add flag for assuming that input is a stream.

### DIFF
--- a/dist/musicmetadata.js
+++ b/dist/musicmetadata.js
@@ -259,10 +259,10 @@ var musicmetadata = require('./index')
 var Stream = require('stream').Stream
 
 module.exports = function (stream, opts, callback) {
-  return musicmetadata(wrapFileWithStream(stream), opts, callback)
+  return musicmetadata(wrapFileWithStream(stream, opts), opts, callback)
 }
 
-function wrapFileWithStream (file) {
+function wrapFileWithStream (file, opts) {
   var stream = through(function write (data) {
     if (data.length > 0) this.queue(data)
   }, null, {autoDestroy: false})
@@ -277,7 +277,7 @@ function wrapFileWithStream (file) {
     })
   }
 
-  if (file instanceof Stream) {
+  if (file instanceof Stream || opts.assumeStream) {
     return file.pipe(stream)
   }
   if (file instanceof window.FileList) {

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -6,10 +6,10 @@ var musicmetadata = require('./index')
 var Stream = require('stream').Stream
 
 module.exports = function (stream, opts, callback) {
-  return musicmetadata(wrapFileWithStream(stream), opts, callback)
+  return musicmetadata(wrapFileWithStream(stream, opts), opts, callback)
 }
 
-function wrapFileWithStream (file) {
+function wrapFileWithStream (file, opts) {
   var stream = through(function write (data) {
     if (data.length > 0) this.queue(data)
   }, null, {autoDestroy: false})
@@ -24,7 +24,7 @@ function wrapFileWithStream (file) {
     })
   }
 
-  if (file instanceof Stream) {
+  if (file instanceof Stream || opts.assumeStream) {
     return file.pipe(stream)
   }
   if (file instanceof window.FileList) {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   "browser": "lib/browser",
   "scripts": {
     "pretest": "standard && jshint lib/*.js test/*.js",
-    "test": "[ ! -d 'test/' ] && echo 'The test directory is not included with the project due to the size of the test audio files. If you want to run the tests you can git clone the project.' || prova test/test-*.js",
+    "test": "[ ! -d 'test/' ] && echo 'The test directory is not included with the project due to the size of the test audio files. If you want to run the tests you can git clone the project.' || tape test/test-*.js",
     "test-browser": "prova -t brfs test/test-*.js -b",
     "dist": "browserify lib/browser.js --standalone 'musicmetadata' -o dist/musicmetadata.js"
   },
   "devDependencies": {
-    "prova": "~2.1.1",
+    "tape": "^4.5.1",
     "jshint": "~2.5.10",
     "brfs": "1.2.0",
     "standard": "^3.0.0"

--- a/test/test-apev2-monkeysaudio.js
+++ b/test/test-apev2-monkeysaudio.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('monkeysaudio (.ape)', function (t) {
   t.plan(33)

--- a/test/test-asf.js
+++ b/test/test-asf.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var mm = require('..')
 var fs = require('fs')
-var test = require('prova')
+var test = require('tape')
 
 test('asf', function (t) {
   t.plan(24)

--- a/test/test-audio-frame-header-bug.js
+++ b/test/test-audio-frame-header-bug.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var mm = require('..')
 var fs = require('fs')
-var test = require('prova')
+var test = require('tape')
 
 test('audio-frame-header-bug', function (t) {
   t.plan(2)

--- a/test/test-concurrent-picture.js
+++ b/test/test-concurrent-picture.js
@@ -1,6 +1,6 @@
 var mm = require('..')
 var fs = require('fs')
-var test = require('prova')
+var test = require('tape')
 
 test('concurrent-picture', function (t) {
   t.plan(6)

--- a/test/test-findzero.js
+++ b/test/test-findzero.js
@@ -1,5 +1,5 @@
 var common = require('../lib/common')
-var test = require('prova')
+var test = require('tape')
 
 var findZero = common.findZero
 

--- a/test/test-flac.js
+++ b/test/test-flac.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('flac', function (t) {
   t.plan(38)

--- a/test/test-id3v1.1.js
+++ b/test/test-id3v1.1.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v1.1', function (t) {
   t.plan(17)

--- a/test/test-id3v2-duration-allframes.js
+++ b/test/test-id3v2-duration-allframes.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v2-duration-allframes', function (t) {
   t.plan(3)

--- a/test/test-id3v2-unknownframe.js
+++ b/test/test-id3v2-unknownframe.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var Mmd = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('invalid "Date" frame should not cause crash', function (t) {
   t.plan(7)

--- a/test/test-id3v2-utf16encoded.js
+++ b/test/test-id3v2-utf16encoded.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v2.4', function (t) {
   t.plan(10)

--- a/test/test-id3v2-xheader.js
+++ b/test/test-id3v2-xheader.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('should be able to read id3v2 files with extended headers', function (t) {
   t.plan(3)

--- a/test/test-id3v2.2.js
+++ b/test/test-id3v2.2.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v2.2', function (t) {
   t.plan(45)

--- a/test/test-id3v2.3.js
+++ b/test/test-id3v2.3.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var id3 = require('..')
 var fs = require('fs')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v2.3', function (t) {
   t.plan(40)

--- a/test/test-id3v2.4.js
+++ b/test/test-id3v2.4.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v2.4', function (t) {
   t.plan(57)

--- a/test/test-id4.js
+++ b/test/test-id4.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id4', function (t) {
   t.plan(49)

--- a/test/test-js-deunsync.js
+++ b/test/test-js-deunsync.js
@@ -1,5 +1,5 @@
 var common = require('../lib/common')
-var test = require('prova')
+var test = require('tape')
 
 test('should be able to remove unsync bytes from buffer', function (t) {
   var expected = new Buffer([0xFF, 0xD8, 0xFF, 0xE0, 0x00])

--- a/test/test-js-genres.js
+++ b/test/test-js-genres.js
@@ -1,5 +1,5 @@
 var parseGenre = require('../lib/common').parseGenre
-var test = require('prova')
+var test = require('tape')
 
 test('should be able to parse genres', function (t) {
   var tests = {

--- a/test/test-js-regress-GH-14.js
+++ b/test/test-js-regress-GH-14.js
@@ -1,5 +1,5 @@
 var common = require('../lib/common')
-var test = require('prova')
+var test = require('tape')
 
 test('should be able to detect ftypmp42 as a valid mp4 header type', function (t) {
   var buf = new Buffer([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34, 0x32])

--- a/test/test-js-stripnulls.js
+++ b/test/test-js-stripnulls.js
@@ -1,5 +1,5 @@
 var stripNulls = require('../lib/common').stripNulls
-var test = require('prova')
+var test = require('tape')
 
 test('readUInt64LE', function (t) {
   var tests = [

--- a/test/test-m4a-ffmpeg-1.js
+++ b/test/test-m4a-ffmpeg-1.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('error handling', function (t) {
   t.plan(1)

--- a/test/test-m4a-ffmpeg-2.js
+++ b/test/test-m4a-ffmpeg-2.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('error handling', function (t) {
   t.plan(1)

--- a/test/test-no-metadata.js
+++ b/test/test-no-metadata.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test("shouldn't raise metadata event for files that can't be parsed", function (t) {
   t.plan(1)

--- a/test/test-non-file-stream-duration.js
+++ b/test/test-non-file-stream-duration.js
@@ -2,7 +2,7 @@
 // var fs = require('fs')
 // var through = require('through')
 // var mm = require('..')
-// var test = require('prova')
+// var test = require('tape')
 
 /* TODO: fix this test. There's a weird race condition when running the full
   test suite that causes this test only to fail. If we remove the

--- a/test/test-nonasciichars.js
+++ b/test/test-nonasciichars.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('nonasciichars', function (t) {
   t.plan(2)

--- a/test/test-ogg-multipagemetadatabug.js
+++ b/test/test-ogg-multipagemetadatabug.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var mm = require('..')
 var fs = require('fs')
-var test = require('prova')
+var test = require('tape')
 
 test('ogg-multipage-metadata-bug', function (t) {
   t.plan(13)

--- a/test/test-ogg.js
+++ b/test/test-ogg.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var mm = require('..')
 var fs = require('fs')
-var test = require('prova')
+var test = require('tape')
 
 test('ogg', function (t) {
   t.plan(49)

--- a/test/test-regress-GH-56.js
+++ b/test/test-regress-GH-56.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('mp3 cbr calculation', function (t) {
   t.plan(2)

--- a/test/test-ufid.js
+++ b/test/test-ufid.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('id3v2.4', function (t) {
   t.plan(2)

--- a/test/test-unexpected-eos.js
+++ b/test/test-unexpected-eos.js
@@ -1,5 +1,5 @@
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 var through = require('through')
 var common = require('../lib/common')
 

--- a/test/test-unknownencoding.js
+++ b/test/test-unknownencoding.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 var mm = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('should be able to read metadata with unknown encoding', function (t) {
   t.plan(11)

--- a/test/test-utf16bom-encoding.js
+++ b/test/test-utf16bom-encoding.js
@@ -1,7 +1,7 @@
 var id3 = require('..')
 var fs = require('fs')
 var path = require('path')
-var test = require('prova')
+var test = require('tape')
 
 test('should read utf16bom encoded metadata correctly', function (t) {
   t.plan(9)

--- a/test/test-zerobytes.js
+++ b/test/test-zerobytes.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var fs = require('fs')
 var id3 = require('..')
-var test = require('prova')
+var test = require('tape')
 
 test('zero bytes', function (t) {
   t.plan(1)


### PR DESCRIPTION
Currently the check for whether the input is a stream, is simply a `instanceof`
check against `require('stream').Stream`, but plenty of other streams may be as
feasible to provide.

Having the possibility to flag that the input does indeed fulfill the interface
of a readable node stream, spares one the trouble of superfluous wrapping;

```js
var readable = ... // An arbitary complient readable node stream.

var Stream = require('stream');
var src = new Stream();
src.readable = true;
var parser = mm(src, function(err, metadata)
{
    if (err) throw err;
    console.log(metadata);
});

readable.on('data', (chunk) => {
    src.emit('data', chunk);
});

readable.on('close', (chunk) => {
    src.emit('close', chunk);
});
```