### PR TITLE
Added missing invocation to callback

### DIFF
--- a/lib/id3v2.js
+++ b/lib/id3v2.js
@@ -53,6 +53,7 @@ module.exports = function (stream, callback, done, readDuration, fileSize) {
 
         // we have found the id3 tag at the end of the file, ignore
         if (v.slice(0, 3).toString() === 'TAG') {
+          done()
           return strtok.DONE
         }
 


### PR DESCRIPTION
A callback to `parser()` from `id3v2.js` is not invoked for [this attached file](https://github.com/leetreveil/musicmetadata/files/315382/sample.zip). Even if this PR seems to fix the issue, but is quick-and-dirty. Feel free to close the PR and take a permanent solution.
