### PR TITLE
Drop the sum-component dependency

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -88,6 +88,15 @@ exports.findZero = function (buffer, start, end, encoding) {
   }
 }
 
+exports.sum = function (arr) {
+  var s = 0
+  var i
+  for (i = 0; i < arr.length; i++) {
+    s += arr[i]
+  }
+  return s
+}
+
 function swapBytes (buffer) {
   var l = buffer.length
   if (l & 0x01) {

--- a/lib/ogg.js
+++ b/lib/ogg.js
@@ -2,7 +2,7 @@
 var events = require('events')
 var strtok = require('strtok2')
 var common = require('./common')
-var sum = require('sum-component')
+var sum = common.sum
 
 module.exports = function (stream, callback, done, readDuration) {
   var innerStream = new events.EventEmitter()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "filereader-stream": "^0.2.0",
     "is-stream": "^1.1.0",
     "strtok2": "~1.0.0",
-    "sum-component": "^0.1.1",
     "through": "~2.3.4"
   },
   "keywords": [


### PR DESCRIPTION
I am using this package inside a Meteor app, and I keep getting this error message when starting the app:

```
Unable to resolve some modules:

  "props" in /Users/runarberg/src/meteor-app/apophis/node_modules/musicmetadata/node_modules/sum-component/node_modules/to-function/index.js (os.osx.x86_64)

If you notice problems related to these missing modules, consider running:

  meteor npm install --save props
```

Inspecting this repo reveals that the `sum-component` dependency is only used in a [single location](https://github.com/leetreveil/musicmetadata/blob/9209b4f52b6a5cf40a1fdafc104ab5d0e2b9db7d/lib/ogg.js#L53) where a simple for loop can do the trick. Thus the package [sum-component](https://www.npmjs.com/package/sum-component) is definitely an overkill.

I suggest removing this dependency in favor of a dumb utility function that we have all written a million times before.